### PR TITLE
Rename `client.call()` to `client.method()`

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -233,9 +233,9 @@ Client.prototype.ondisconnected = function() {
   thread.disconnection('outbound');
 };
 
-Client.prototype.call = function(method) {
+Client.prototype.method = function(method) {
   var args = [].slice.call(arguments, 1);
-  debug('call', method, args);
+  debug('method', method, args);
   return this.request('method', {
     name: method,
     args: args

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -55,7 +55,7 @@ suite('client', function() {
         done();
       });
 
-      client.call('testBroadcast', 'test-event', { event: 'data' });
+      client.method('testBroadcast', 'test-event', { event: 'data' });
     });
   });
 
@@ -69,7 +69,7 @@ suite('client', function() {
 
       var client = threads.client('little-browser', { thread: thread });
 
-      client.call('getTitle').then(title => {
+      client.method('getTitle').then(title => {
         assert.equal(title, 'page-title');
         done();
       });
@@ -83,7 +83,7 @@ suite('client', function() {
 
       var client = threads.client('view-server', { thread: thread });
 
-      client.call('getData').then(data => {
+      client.method('getData').then(data => {
         assert.deepEqual(data, { some: 'data' });
         done();
       });
@@ -97,7 +97,7 @@ suite('client', function() {
 
       var client = threads.client('view-server', { thread: thread });
 
-      client.call('getData').then(data => {
+      client.method('getData').then(data => {
         assert.deepEqual(data, { some: 'data' });
         done();
       });
@@ -114,7 +114,7 @@ suite('client', function() {
       thread.on('serviceready', service => {
         var client = threads.client('thread2-service');
 
-        client.call('getData').then(data => {
+        client.method('getData').then(data => {
           assert.deepEqual(data, { some: 'data' });
           done();
         });

--- a/test/manager.test.js
+++ b/test/manager.test.js
@@ -26,7 +26,7 @@ suite('Manager', function() {
 
   test('simple call', function(done) {
     client = threads.client('view-server');
-    client.call('getData').then(data => {
+    client.method('getData').then(data => {
       assert.deepEqual(data, { some: 'data' });
       done();
     });
@@ -54,8 +54,8 @@ suite('Manager', function() {
       client2 = threads.client('view-server');
 
       Promise.all([
-        client1.call('getData'),
-        client2.call('getData')
+        client1.method('getData'),
+        client2.method('getData')
       ]).then(results => {
         assert.deepEqual(results[0], { some: 'data' });
         assert.deepEqual(results[1], { some: 'data' });

--- a/test/service.test.js
+++ b/test/service.test.js
@@ -35,13 +35,13 @@ suite('Service /', function() {
     });
 
     test('contract method calls are allowed', function(done) {
-      this.client.call('contractMethod', 'foo').then(result => {
+      this.client.method('contractMethod', 'foo').then(result => {
         assert.equal(result, 'conformance: foo');
       }).then(done, done);
     });
 
     test('uncontracted method calls throw', function(done) {
-      this.client.call('uncontractMethod').then(result => {
+      this.client.method('uncontractMethod').then(result => {
         assert.equal(result, 'rebellion');
         done('should not be called');
       }).catch(err => {
@@ -51,7 +51,7 @@ suite('Service /', function() {
     });
 
     test('calling with incorrect argument type throws', function(done) {
-      this.client.call('contractMethod', {}).then(result => {
+      this.client.method('contractMethod', {}).then(result => {
         assert.equal(result, 'rebellion');
         done('should not be called');
       }).catch(err => {
@@ -61,7 +61,7 @@ suite('Service /', function() {
     });
 
     test('calling with incorrect arguments.length throws', function(done) {
-      this.client.call('contractMethod', '1', '2', '3').then(result => {
+      this.client.method('contractMethod', '1', '2', '3').then(result => {
         assert.equal(result, 'rebellion');
         done('should not be called');
       }).catch(err => {
@@ -84,13 +84,13 @@ suite('Service /', function() {
     });
 
     test('contract method calls are allowed', function(done) {
-      this.client.call('contractMethod', 'foo').then(result => {
+      this.client.method('contractMethod', 'foo').then(result => {
         assert.equal(result, 'conformance: foo');
       }).then(done, done);
     });
 
     test('uncontracted method calls throw', function(done) {
-      this.client.call('uncontractMethod').then(result => {
+      this.client.method('uncontractMethod').then(result => {
         assert.equal(result, 'rebellion');
         done('should not be called');
       }).catch(err => {

--- a/threads.js
+++ b/threads.js
@@ -400,9 +400,9 @@ Client.prototype.ondisconnected = function() {
   thread.disconnection('outbound');
 };
 
-Client.prototype.call = function(method) {
+Client.prototype.method = function(method) {
   var args = [].slice.call(arguments, 1);
-  debug('call', method, args);
+  debug('method', method, args);
   return this.request('method', {
     name: method,
     args: args


### PR DESCRIPTION
Since `call` is a native method of the `Function.prototype` it can
be confusing.

We also have plans to add methods to the service that returns a
Stream instead of a Promise, so it's better to use a name that
avoids ambiguity.

closes #5
see #6
